### PR TITLE
Ensure getting real releases, only master branch, fix headers folder name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - mkdir -p output/include
   - cp shaders/*.h output/include/
   - cp libvitashaders.a output/lib/
-  - tar -zcvf vita-shader-collection.tar.gz -C output .
+  - tar -zcvf vita-shader-collection.tar.gz -C output include lib
 env:
  global:
   - TOP=$PWD

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_install:
 script:
   - make
   - mkdir -p output/lib
-  - mkdir -p output/includes
-  - cp shaders/*.h output/includes/
+  - mkdir -p output/include
+  - cp shaders/*.h output/include/
   - cp libvitashaders.a output/lib/
   - tar -zcvf vita-shader-collection.tar.gz -C output .
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ os:
 language: c
 
 before_install:
-  - sudo apt-get install qemu-kvm qemu qemu-user-static
-  - curl https://api.github.com/repos/vitasdk/autobuilds/releases  | grep browser_download_url | grep linux | head -n 1 | cut -d '"' -f 4 | xargs wget
-  - tar xjf *.tar.bz2
+  - sudo apt-get install qemu-kvm qemu qemu-user-static jq
+  - curl -L "https://api.github.com/repos/vitasdk/autobuilds/releases?per_page=100" | jq -r '[.[] | select(.prerelease | not)][].assets[].browser_download_url' | grep 'master' | grep 'x86_64-linux' | head -n 1 | xargs curl -L | tar xj
   - export VITASDK=$PWD/vitasdk
   - export PATH=$VITASDK/bin:$PATH
   - wget https://releases.linaro.org/archive/15.02/components/toolchain/binaries/arm-linux-gnueabihf/gcc-linaro-4.9-2015.02-3-x86_64_arm-linux-gnueabihf.tar.xz

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,8 @@ before_install:
   - curl -L "https://api.github.com/repos/vitasdk/autobuilds/releases?per_page=100" | jq -r '[.[] | select(.prerelease | not)][].assets[].browser_download_url' | grep 'master' | grep 'x86_64-linux' | head -n 1 | xargs curl -L | tar xj
   - export VITASDK=$PWD/vitasdk
   - export PATH=$VITASDK/bin:$PATH
-  - wget https://releases.linaro.org/archive/15.02/components/toolchain/binaries/arm-linux-gnueabihf/gcc-linaro-4.9-2015.02-3-x86_64_arm-linux-gnueabihf.tar.xz
-  - tar xf gcc-linaro-4.9-2015.02-3-x86_64_arm-linux-gnueabihf.tar.xz
+  - curl -L "https://releases.linaro.org/archive/15.02/components/toolchain/binaries/arm-linux-gnueabihf/gcc-linaro-4.9-2015.02-3-x86_64_arm-linux-gnueabihf.tar.xz" | tar xJ
   - export PATH=$(pwd)/gcc-linaro-4.9-2015.02-3-x86_64_arm-linux-gnueabihf/bin:$PATH
-  - rm gcc-linaro-4.9-2015.02-3-x86_64_arm-linux-gnueabihf.tar.xz
   - git clone https://github.com/JagerDesu/vita-shaders
   - cd vita-shaders
   - make


### PR DESCRIPTION
This ensures it'll always get a release with `"prerelease": false`, even if there's a newer prerelease
Ensures the release will always be from the master branch (by name, not the strongest guarantee, but better than nothing)
It also avoids saving the file to disk by piping the output from `curl` directly to `tar` 
Add -L parameter to curl so it follows redirects (necessary for fetching the archive).

I also renamed the `includes` folder to `include`, which is the standard way of naming the folders containing header files, and I got rid of the `.` root directory on the tar archive. Now installing it to the VitaSDK folder is just a `tar xz -C "${VITASDK}/arm-vita-eabi"` and the headers will go into the right directory.